### PR TITLE
2주차 1단계 : 웹 성능 테스트

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,35 +19,85 @@
 ## 🚀 Getting Started
 
 ### Install
+
 #### npm 설치
+
 ```
 cd frontend
 npm install
 ```
+
 > `frontend` 디렉토리에서 수행해야 합니다.
 
 ### Usage
+
 #### webpack server 구동
+
 ```
 npm run dev
 ```
+
 #### application 구동
+
 ```
 ./gradlew clean build
 ```
+
 <br>
 
-
 ### 1단계 - 웹 성능 테스트
+
 1. 웹 성능예산은 어느정도가 적당하다고 생각하시나요
+
+- 측정 :
+
+| mobile       | FCP   | TTI   | LCP   | SCORE |
+| ------------ | ----- | ----- | ----- | ----- |
+| subway       | 15.1s | 15.7s | 15.6s | 30    |
+| 서울도로공사 | 7.2s  | 10.9s | 12.8s | 33    |
+| 네이버지도   | 2.2s  | 6.5s  | 8.2s  | 57    |
+| 카카오맵     | 1.7s  | 4.2s  | 4.7s  | 74    |
+
+| pc           | FCP  | TTI  | LCP  | SCORE |
+| ------------ | ---- | ---- | ---- | ----- |
+| subway       | 2.7s | 2.8s | 2.8s | 67    |
+| 서울도로공사 | 1.7s | 2.2s | 4.0s | 63    |
+| 네이버지도   | 0.5s | 0.7s | 1.7s | 87    |
+| 카카오맵     | 0.5s | 0.7s | 1.1s | 92    |
+
+- 목표 성능 예산 :
+  - `서울교통공사`도 (개인적으로 생각하기에) 성능 예산이 좋지 않다고 판단하여 제외
+  - `카카오맵`과 `네이버지도`가 상대적으로 성능 예산이 좋기때문에 이 두개와 비교하여 `목표 성능 예산`을 결정
+    - `카카오맵`과 `네이버지도`의 성능 예산 범위 사이
+    - `카카오맵`의 성능 예산과 `20%` 이상 차이 나지 않도록 잡음
+
+| mobile | FCP   | TTI   | LCP   | SCORE |
+| ------ | ----- | ----- | ----- | ----- |
+| subway | <= 2s | <= 5s | <= 5s | >= 60 |
+
+| pc     | FCP     | TTI     | LCP     | SCORE |
+| ------ | ------- | ------- | ------- | ----- |
+| subway | <= 0.5s | <= 0.7s | <= 1.4s | >= 90 |
 
 2. 웹 성능예산을 바탕으로 현재 지하철 노선도 서비스는 어떤 부분을 개선하면 좋을까요
 
-
+- 캐시 사용하기
+  - js, css, png 등에 대해 캐시 사용하기
+- resource (js, css, etc)에 대해 gzip 압축
+- js 크기 줄이기
+  - `/js/vendors.js`의 크기가 많이 크다고 생각됨. analyze 통해 줄일수 있는 부분 파악 필요.
+- css 수정
+  - `<style>` 대신 `<link rel="stylesheet">` 형태로 로드..? (너무 많은 <style> 태그로 나누어져 있는게 아닌지 생각됨)
+- font 최적화
+  - 웹폰트 크기가 너무 큰 경우, 페이지 로딩 속도가 늦어짐
+  - google font (`&display=swap`), @font-face (`font-display: swap;`) 등 추가 (참고 : https://web.dev/font-display/?utm_source=lighthouse&utm_medium=lr)
+- 리소스 lazy load
+  - 첫페이지 로드에 필요하지 않은 리소스는 lazy-load나 parallel-load 로 불러오도록 수정
 
 ---
 
-### 2단계 - 부하 테스트 
+### 2단계 - 부하 테스트
+
 1. 부하테스트 전제조건은 어느정도로 설정하셨나요
 
 2. Smoke, Load, Stress 테스트 스크립트와 결과를 공유해주세요
@@ -55,6 +105,7 @@ npm run dev
 ---
 
 ### 3단계 - 로깅, 모니터링
+
 1. 각 서버내 로깅 경로를 알려주세요
 
 2. Cloudwatch 대시보드 URL을 알려주세요

--- a/performance.md
+++ b/performance.md
@@ -1,0 +1,124 @@
+- 경쟁사와 시간 비교
+
+  - 메인 페이지 (모바일)
+    - subway :
+      - 성능 : 30점
+      - FCP : 15.1s
+      - TTI : 15.7s
+      - LCP : 15.6s
+    - 서울교통공사 :
+      - 성능 : 33점
+      - FCP : 7.2s
+      - TTI : 10.9s
+      - LCP : 12.8s
+    - 네이버지도 :
+      - 성능 : 57점
+      - FCP : 2.2s
+      - TTI : 6.5s
+      - LCP : 8.2s
+    - 카카오맵 :
+      - 성능 : 74점
+      - FCP : 1.7s
+      - TTI : 4.2s
+      - LCP : 4.7s
+  - 메인 페이지 (PC)
+
+    - subway :
+      - 성능 : 67점
+      - FCP : 2.7s
+      - TTI : 2.8s
+      - LCP : 2.8s
+    - 서울교통공사 :
+      - 성능 : 63점
+      - FCP : 1.7s
+      - TTI : 2.2s
+      - LCP : 4.0s
+    - 네이버지도 :
+      - 성능 : 87점
+      - FCP : 0.5s
+      - TTI : 0.7s
+      - LCP : 1.7s
+    - 카카오맵 :
+      - 성능 : 92점
+      - FCP : 0.5s
+      - TTI : 0.7s
+      - LCP : 1.1s
+
+  - 역관리 (모바일)
+    - 성능 : 15점
+    - FCP : 16.3s
+    - TTI : 23.9s
+    - LCP : 16.3s
+  - 역관리 (PC)
+
+    - 성능 : 30점
+    - FCP : 3.0s
+    - TTI : 5.3s
+    - LCP : 3.0s
+
+  - 노선관리 (모바일)
+    - 성능 : 9점
+    - FCP : 16.4s
+    - TTI : 18.5s
+    - LCP : 16.5s
+  - 노선관리 (PC)
+
+    - 성능 : 46점
+    - FCP : 3.0s
+    - TTI : 3.5s
+    - LCP : 3.0s
+
+  - 구관관리 (모바일)
+    - 성능 : 46점
+    - FCP : 16.3s
+    - TTI : 16.6s
+    - LCP : 16.3s
+  - 구관관리 (PC)
+
+    - 성능 : 65점
+    - FCP : 3.0s
+    - TTI : 3.0s
+    - LCP : 2.9s
+
+  - 경로검색 (모바일)
+    - 성능 : 41점
+    - FCP : 16.5s
+    - TTI : 172.s
+    - LCP : 16.5s
+  - 경로검색 (PC)
+
+    - 성능 : 65점
+    - FCP : 3.0s
+    - TTI : 3.2s
+    - LCP : 3.0s
+
+  - 로그인 (모바일)
+
+    - 성능 : 46점
+    - FCP : 16.5s
+    - TTI : 16.4s
+    - LCP : 16.4s
+
+  - 로그인 (PC)
+    - 성능 : 65점
+    - FCP : 2.9s
+    - TTI : 2.9s
+    - LCP : 2.9s
+
+---
+- 경쟁사 '네이버'와 '카카오'를 기준으로 성능 예산 측정 (according to PageSpeed)
+  - Quantity based Metric :
+    - 카카오, 네이버 측정 후 잡아보자.
+  - Timing based Metric :
+    - mobile : 
+      - FCP : <= 2s
+      - TTI : <= 5s
+      - LCP : <= 5s
+    - pc :
+      - FCP : <= 0.5s
+      - TTI : <= 0.7s
+      - LCP : <= 1.4s
+
+  - Rule based Metric :
+    - mobile : >= score 60
+    - pc : >= score 90


### PR DESCRIPTION
- subway (https://writer0713.o-r.kr/) 성능 측정 및 타사 성능 측정 (mobile/pc)
- 타사 성능측정과 비교하여 '목표 성능 예산' 도출
- '목표 성능 예산'에 도달하기 위해 개선할수 있는 부분 추가
--
- 질문 : 
  - `목표 성능 예산`에 도달하기 위해 개선할수 있는 부분을 적을때 `fe`에서 할수있는 부분만 우선 생각을 해봤습니다.
  - `목표 성능 예산`에는 `server`에서의 `response time`도 영향을 줄수있을거 같은데요.
    - 페이지에 따라 다르겠지만, 만약 `server`에 대한 `request/response`가 포함되는 페이지는 `개선 부분`에 서버쪽 개선도 포함이 될수 있을거라 생각이되는데, 맞을까요?
    - 물론, 추후 `부하테스트` 등을 진행하겠지만 `부하테스트`는 `tps` 등에 대한 측정 및 목표치 달성을 위한 과정이라고 생각이되고
    - 서버 측의 response time 최적화 (ex. sql 튜닝, 알고리즘 변화 등)은 `목표 성능 예산 도달을 위한 개선 부분`에 포함되는야 할거 같은데 맞는지 답변 부탁드립니다 :) 