### PR TITLE
step3: 로깅, 모니터링

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,5 +252,11 @@ export default function ()  {
 
 ### 3단계 - 로깅, 모니터링
 1. 각 서버내 로깅 경로를 알려주세요
+- soosue-public-web
+  - /home/ubuntu/nextstep/infra-subway-monitoring/log/file.log 
+  - /home/ubuntu/nextstep/infra-subway-monitoring/log/json.log
+  - /var/log/nginx/access.log
+  - /var/log/nginx/error.log
 
 2. Cloudwatch 대시보드 URL을 알려주세요
+- https://ap-northeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-2#dashboards:name=soosue-dashboard

--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ smoke test
 ![smoke-text](./image/smoke-text.PNG)
 ![smoke](./image/smoke.PNG)
 ```javascript
-import http from 'k6/http';
-import { check, group, sleep, fail } from 'k6';
+import scenario from './scenario.js';
 
 export let options = {
   vus: 1,
@@ -130,28 +129,8 @@ export let options = {
   },
 };
 
-const BASE_URL = 'https://enfunha.kro.kr/';
-
 export default function ()  {
-
-  let main = http.get(BASE_URL);
-  check(main, {
-    'move to main page success': (res) => res.status === 200,
-  });
-
-  let path = http.get(`${BASE_URL}/path`);
-  check(path, {
-    'move to path page success': (res) => res.status === 200,
-  });
-
-  const source = 1;
-  const target = 6;
-  let findPath = http.get(`${BASE_URL}/paths?source=${source}&target=${target}`);
-  check(findPath, {
-    'find path from source to target success': (res) => res.status === 200 && res.json().stations.size !== 0,
-  });
-
-  sleep(1);
+  scenario();
 };
 
 ```
@@ -159,8 +138,7 @@ export default function ()  {
 load test
 ![load](./image/load.PNG)
 ```javascript
-import http from 'k6/http';
-import { check, group, sleep, fail } from 'k6';
+import scenario from './scenario.js';
 
 export let options = {
   stages: [
@@ -173,37 +151,17 @@ export let options = {
   },
 };
 
-const BASE_URL = 'https://enfunha.kro.kr/';
-
 export default function ()  {
-
-  let main = http.get(BASE_URL);
-  check(main, {
-    'move to main page success': (res) => res.status === 200,
-  });
-
-  let path = http.get(`${BASE_URL}/path`);
-  check(path, {
-    'move to path page success': (res) => res.status === 200,
-  });
-
-  const source = 1;
-  const target = 6;
-  let findPath = http.get(`${BASE_URL}/paths?source=${source}&target=${target}`);
-  check(findPath, {
-    'find path from source to target success': (res) => res.status === 200 && res.json().stations.size !== 0,
-  });
-
-  sleep(1);
+  scenario();
 };
+
 ```
 ---
 stress test
 ![stress-text](./image/stress-text.PNG)
 ![stress](./image/stress.PNG)
 ```javascript
-import http from 'k6/http';
-import { check, group, sleep, fail } from 'k6';
+import scenario from './scenario.js';
 
 export let options = {
   stages: [
@@ -224,10 +182,20 @@ export let options = {
   },
 };
 
+export default function ()  {
+  scenario();
+};
+
+```
+---
+scenario.js
+```javascript
+import http from 'k6/http';
+import { check, group, sleep, fail } from 'k6';
+
 const BASE_URL = 'https://enfunha.kro.kr/';
 
 export default function ()  {
-
   let main = http.get(BASE_URL);
   check(main, {
     'move to main page success': (res) => res.status === 200,
@@ -238,8 +206,14 @@ export default function ()  {
     'move to path page success': (res) => res.status === 200,
   });
 
-  const source = 1;
-  const target = 6;
+  let findStations = http.get(`${BASE_URL}/stations`);
+  check(findStations, {
+    'find stations success': (res) => res.status === 200 && res.json().length !== 0,
+  });
+  const stations = findStations.json();
+
+  const source = getRandomStationId(stations);
+  const target = getRandomStationId(stations);
   let findPath = http.get(`${BASE_URL}/paths?source=${source}&target=${target}`);
   check(findPath, {
     'find path from source to target success': (res) => res.status === 200 && res.json().stations.size !== 0,
@@ -247,6 +221,16 @@ export default function ()  {
 
   sleep(1);
 };
+
+function getRandomStationId(stations) {
+  return stations[getRandomIntExclusive(16)].id;
+  //return stations[getRandomIntExclusive(stations.length)].id;
+}
+
+function getRandomIntExclusive(maxNumber) {
+  return Math.floor(Math.random() * maxNumber);
+}
+
 ```
 ---
 
@@ -260,3 +244,4 @@ export default function ()  {
 
 2. Cloudwatch 대시보드 URL을 알려주세요
 - https://ap-northeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-northeast-2#dashboards:name=soosue-dashboard
+

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 
 	// log
 	implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
+	implementation("net.logstash.logback:logstash-logback-encoder:6.1")
 
 	// jgraph
 	implementation 'org.jgrapht:jgrapht-core:1.0.1'

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+txtrst='\033[1;37m' # White
+txtred='\033[1;31m' # Red
+txtylw='\033[1;33m' # Yellow
+txtpur='\033[1;35m' # Purple
+txtgrn='\033[1;32m' # Green
+txtgra='\033[1;30m' # Gray
+
+echo -e "${txtylw}=======================================${txtrst}"
+echo -e "${txtgrn}  << 스크립트 🧐 >>${txtrst}"
+echo -e "${txtylw}=======================================${txtrst}"
+
+BRANCH=soosue
+
+function check_df() {
+	git fetch
+	local=$(git rev-parse $BRANCH)
+	remote=$(git rev-parse origin/$BRANCH)
+
+	if [[ $local == $remote ]]; then
+		echo -e "[$(date)] Nothing to do!!!"
+		read -p "continue? y/n > " input
+		if [[ $input == y ]]; then
+			echo -e ""
+		else
+			exit 1
+		fi
+	fi
+}
+
+function pull() {
+	echo -e ""
+	echo -e ">> Pull from the remote "
+	git pull origin $BRANCH
+}
+
+function build() {
+	./gradlew clean build
+}
+
+function kill_app() {
+	pid=$(pgrep -f java)
+	kill -9 $pid
+}
+
+function start_app() {
+	nohup java -Djava.security.egd=file:/dev/./urandom -Dserver.port=8081 -Dspring.profiles.active=prod -jar ./build/libs/subway-0.0.1-SNAPSHOT.jar 1> ./applog 2>&1 &
+}
+
+check_df;
+pull;
+build;
+kill_app;
+start_app;

--- a/src/main/java/nextstep/subway/PageController.java
+++ b/src/main/java/nextstep/subway/PageController.java
@@ -1,11 +1,17 @@
 package nextstep.subway;
 
+import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class PageController {
+    private static final Logger log = LoggerFactory.getLogger("file");
+
     @GetMapping(value = {
             "/",
             "/stations",
@@ -17,7 +23,8 @@ public class PageController {
             "/mypage",
             "/mypage/edit",
             "/favorites"}, produces = MediaType.TEXT_HTML_VALUE)
-    public String index() {
+    public String index(HttpServletRequest request) {
+        log.info("page in: {} {}", request.getRemoteAddr(), request.getServletPath());
         return "index";
     }
 }

--- a/src/main/java/nextstep/subway/exception/ExceptionHandlers.java
+++ b/src/main/java/nextstep/subway/exception/ExceptionHandlers.java
@@ -1,0 +1,22 @@
+package nextstep.subway.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionHandlers {
+    private static final Logger log = LoggerFactory.getLogger("file");
+    
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<Void> handleNotEnoughPointException(Exception ex) {
+        log.error("{}", ex.toString());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    }
+}
+

--- a/src/main/java/nextstep/subway/line/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/line/domain/LineRepository.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface LineRepository extends JpaRepository<Line, Long> {
 
-    @Query(value = "SELECT * FROM line WHERE SLEEP(3)", nativeQuery = true)
+    @Query(value = "SELECT * FROM line", nativeQuery = true)
     List<Line> findAll();
 }

--- a/src/main/java/nextstep/subway/map/application/MapService.java
+++ b/src/main/java/nextstep/subway/map/application/MapService.java
@@ -1,5 +1,7 @@
 package nextstep.subway.map.application;
 
+import static net.logstash.logback.argument.StructuredArguments.*;
+
 import nextstep.subway.line.application.LineService;
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.map.domain.SubwayPath;
@@ -7,14 +9,21 @@ import nextstep.subway.map.dto.PathResponse;
 import nextstep.subway.map.dto.PathResponseAssembler;
 import nextstep.subway.station.application.StationService;
 import nextstep.subway.station.domain.Station;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import net.logstash.logback.argument.StructuredArguments;
+
 @Service
 @Transactional
 public class MapService {
+    private static final Logger jsonLog = LoggerFactory.getLogger("json");
+
     private LineService lineService;
     private StationService stationService;
     private PathService pathService;
@@ -26,6 +35,13 @@ public class MapService {
     }
 
     public PathResponse findPath(Long source, Long target) {
+        jsonLog.info("{}", array(
+                        "findPath",
+                        kv("source", source),
+                        kv("target", target)
+                )
+        );
+
         List<Line> lines = lineService.findLines();
         Station sourceStation = stationService.findById(source);
         Station targetStation = stationService.findById(target);

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,15 @@
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://192.168.3.150:3306/subway
+spring.datasource.username=root
+spring.datasource.password=masterpw
+
+handlebars.suffix=.html
+handlebars.enabled=true
+
+logging.level.org.hibernate.type.descriptor.sql=trace
+
+spring.jpa.properties.hibernate.show_sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+security.jwt.token.secret-key= eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno
+security.jwt.token.expire-length= 3600000

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{50} - %msg%n</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/file-appender.xml
+++ b/src/main/resources/file-appender.xml
@@ -1,0 +1,18 @@
+<included>
+    <property name="home" value="log/"/>
+    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${home}file.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${home}file-%d{yyyyMMdd}-%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>15MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+        <encoder>
+            <charset>utf8</charset>
+            <Pattern>
+                %d{yyyy-MM-dd HH:mm:ss.SSS} %thread %-5level %logger - %m%n
+            </Pattern>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/json-appender.xml
+++ b/src/main/resources/json-appender.xml
@@ -1,0 +1,24 @@
+<included>
+    <property name="home" value="log/"/>
+    <appender name="json" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${home}json.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${home}json-%d{yyyyMMdd}-%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>15MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeContext>true</includeContext>
+            <includeCallerData>true</includeCallerData>
+            <timestampPattern>yyyy-MM-dd HH:mm:ss.SSS</timestampPattern>
+            <fieldNames>
+                <timestamp>timestamp</timestamp>
+                <thread>thread</thread>
+                <message>message</message>
+                <stackTrace>exception</stackTrace>
+                <mdc>context</mdc>
+            </fieldNames>
+        </encoder>
+    </appender>
+</included>

--- a/src/main/resources/logback-access.xml
+++ b/src/main/resources/logback-access.xml
@@ -1,9 +1,0 @@
-<configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%fullRequest%n%n%fullResponse</pattern>
-        </encoder>
-    </appender>
-
-    <appender-ref ref="STDOUT" />
-</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration debug="false">
+    <include resource="org/springframework/boot/logging/logback/base.xml" />
+    <include resource="console-appender.xml"/>
+    <include resource="file-appender.xml"/>
+    <include resource="json-appender.xml"/>
+
+    <logger name="console" level="TRACE">
+        <appender-ref ref="console"/>
+    </logger>
+    <logger name="file" level="INFO">
+        <appender-ref ref="file"/>
+    </logger>
+    <logger name="json" level="INFO">
+        <appender-ref ref="json"/>
+    </logger>
+</configuration>


### PR DESCRIPTION
강의 자료 중 부하테스트 options 스크립트의 주석에 `// simulate ramp-up of traffic from 1 to 100 users over 5 minutes.` 를 보고 그렇게 생각을 했었습니다. 성능이랑 테스트에 영향가지 않는 선에서 짧게 가져가면 되는거였군요.

로깅은 성능테스트 하는데 필요한 부분에만 로깅을 하였습니다. (페이지 이동, 역 목록 조회, 경로 검색)

경로 검색에 대해서 데이터 캐시를 안하기 위해 랜덤값을 추가했습니다. (일부 역에 대한 line 데이터가 존재하지 않아서 전체 값에 대한 random 값 사용은 불가능하네요. 편의를 위해 1~16번 역에 대해서 했습니다)

cloudwatch 대시보드에는 nginx 로그를 추가해봤는데, 이런 식으로 하는게 맞는지 모르겠네요;;

그리고 thread 덤프와 Arthas 를 이용해서 스레드 정보를 확인해서 block 인지, 스레드가 얼마나 계속 생성되고 남아있는지 등을 볼 수 있는건 알겠습니다. 그러면 이를 이용해서 스레드를 끄는 방법은 없는건가요? 스레드를 끄려면 애플리케이션을 종료하고 다시 켜야하는지 궁금합니다.

부하테스트 그래프는, 응답시간이 오래 걸려서 그런거 같은데, 성능을 개선해보고 나서 다시 한 번 그려보겠습니다!